### PR TITLE
I added the fix that Jessica pointed out.

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -201,7 +201,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
           new_config);
       config_stack.push(new_config);
     } else if (token_type == TOKEN_TYPE_END_BLOCK) {
-      if (last_token_type != TOKEN_TYPE_STATEMENT_END) {
+      if (last_token_type != TOKEN_TYPE_STATEMENT_END && last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
         break;
       }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -73,3 +73,9 @@ TEST_F(NginxStringConfigTest, BlockEndWithoutBlockStart){
   EXPECT_FALSE(ParseString("hello;}")) << "Allowed end of block without beginning of block";
 
 }
+
+TEST_F(NginxStringConfigTest, AdjacentBraces){ //Thanks to Jessica for this.
+
+  EXPECT_TRUE(ParseString("mmm {bop {shoobydooby;}}")) << "Did not allow adjacent close braces.";
+  EXPECT_FALSE(ParseString("mmm {{bop shoobydooby;}}")) << "Allowed adjacent open braces.";
+}


### PR DESCRIPTION
Issue:

The config parser was returning an error when there were two adjacent close braces.